### PR TITLE
fix(ci): repin setup-go and codecov-action to resolvable SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@d60b41a563a30ca0e303b2e4c7a52a08e34f3b61 # v5.5.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -22,7 +22,7 @@ jobs:
       - name: Test
         run: go test -race -coverprofile=coverage.txt ./...
       - name: Upload coverage
-        uses: codecov/codecov-action@ad3126e916f78f00edff4a0b0a8b6c8e80199af3 # v5.4.2
+        uses: codecov/codecov-action@4481f553995cc5011b158ce191746ac1a1d0f815 # v5.5.3
         with:
           files: coverage.txt
         continue-on-error: true


### PR DESCRIPTION
## Problem
The **build** job failed at job setup:
```
Unable to resolve action `actions/setup-go@d60b41a5...`, unable to find version
```
Both the `setup-go` and `codecov-action` pins point to SHAs not reachable from any tag or branch, so GitHub Actions refuses to run them. **Pre-existing** failure, unrelated to any recent change.

## Fix
Repin to the exact SHAs already passing CI in the sibling adapter repos (ecosystem consistency):

| Action | Was | Now |
|---|---|---|
| `actions/setup-go` | `d60b41a5…` (v5.5.0, unresolvable) | `d35c59ab…` v5.5.0 |
| `codecov/codecov-action` | `ad3126e9…` (v5.4.2, unresolvable) | `4481f553…` v5.5.3 |