### PR TITLE
feat: per-user cross-account AssumeRole seam (#78)

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -14,7 +14,7 @@ var deleteCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
-		client, err := ec2.New(ctx, region)
+		client, err := ec2.New(ctx, region, awsOptions(ctx)...)
 		if err != nil {
 			return err
 		}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -15,7 +15,7 @@ var infoCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
-		client, err := ec2.New(ctx, region)
+		client, err := ec2.New(ctx, region, awsOptions(ctx)...)
 		if err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/scttfrdmn/ood-ec2-adapter/internal/awscfg"
 	"github.com/spf13/cobra"
 )
 
@@ -9,13 +13,19 @@ var (
 	launchTemplate string
 )
 
+var (
+	assumeRoleArn     string // #78: per-user role to assume (empty = instance role)
+	assumeRoleExtID   string
+	assumeRoleSession string
+)
+
 var version = "dev" // overridden at release time via -ldflags -X .../cmd.version
 
 var rootCmd = &cobra.Command{
 	Version: version,
-	Use:   "ood-ec2-adapter",
-	Short: "OOD compute adapter for EC2 single-node jobs",
-	Long:  "Translates Open OnDemand job submissions to EC2 instance launches.",
+	Use:     "ood-ec2-adapter",
+	Short:   "OOD compute adapter for EC2 single-node jobs",
+	Long:    "Translates Open OnDemand job submissions to EC2 instance launches.",
 }
 
 // Execute runs the root command.
@@ -26,4 +36,22 @@ func Execute() error {
 func init() {
 	rootCmd.PersistentFlags().StringVar(&region, "region", "us-east-1", "AWS region")
 	rootCmd.PersistentFlags().StringVar(&launchTemplate, "launch-template", "", "EC2 Launch Template ID")
+}
+
+// #78: per-user cross-account AssumeRole flags. Empty (default) = use the OOD instance role.
+func init() {
+	pf := rootCmd.PersistentFlags()
+	pf.StringVar(&assumeRoleArn, "assume-role-arn", "", "IAM role ARN to assume for AWS calls (empty = use the instance role)")
+	pf.StringVar(&assumeRoleExtID, "assume-role-external-id", "", "sts:ExternalId for the assumed-role trust policy")
+	pf.StringVar(&assumeRoleSession, "assume-role-session-name", "", "RoleSessionName for the assumed role (e.g. the OOD username)")
+}
+
+// awsOptions builds the AWS config options from the root flags (region + optional AssumeRole).
+func awsOptions(ctx context.Context) []func(*config.LoadOptions) error {
+	return awscfg.LoadOptions(ctx, awscfg.Options{
+		Region:        region,
+		AssumeRoleARN: assumeRoleArn,
+		ExternalID:    assumeRoleExtID,
+		SessionName:   assumeRoleSession,
+	})
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -17,7 +17,7 @@ var statusCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
-		client, err := ec2.New(ctx, region)
+		client, err := ec2.New(ctx, region, awsOptions(ctx)...)
 		if err != nil {
 			return err
 		}

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -34,7 +34,7 @@ var submitCmd = &cobra.Command{
 		userdata := base64.StdEncoding.EncodeToString([]byte("#!/bin/bash\n" + spec.Script))
 
 		ctx := context.Background()
-		client, err := ec2.New(ctx, region)
+		client, err := ec2.New(ctx, region, awsOptions(ctx)...)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.0
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9
 	github.com/scttfrdmn/substrate v0.65.0
 	github.com/spf13/cobra v1.10.2
 )
@@ -21,7 +22,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/internal/awscfg/awscfg.go
+++ b/internal/awscfg/awscfg.go
@@ -1,0 +1,55 @@
+// Package awscfg builds the AWS config option set shared by the adapter commands.
+//
+// #78 (aws-openondemand): in the multi-account best-practice topology, an adapter's AWS calls
+// should run in the LOGGING-IN USER's account under a per-user role — not the OOD instance
+// role. When --assume-role-arn is set, this returns an option that wraps the instance-role
+// credentials in an STS AssumeRole provider for that role (with an ExternalID and a session
+// name derived from the OOD username). When it is empty (the default / single-account on-ramp),
+// the behavior is exactly the AWS default credential chain — no AssumeRole, instance role.
+package awscfg
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// Options controls how the adapter obtains AWS credentials.
+type Options struct {
+	Region        string // AWS region
+	AssumeRoleARN string // optional per-user role to assume; empty = use the instance role directly
+	ExternalID    string // optional sts:ExternalId for the AssumeRole trust policy
+	SessionName   string // optional RoleSessionName (e.g. the OOD username); defaults to "ood-adapter"
+}
+
+// LoadOptions returns the config.LoadDefaultConfig option functions for these Options.
+// Always sets the region; appends an AssumeRole credentials provider only when AssumeRoleARN
+// is set. Empty AssumeRoleARN yields exactly the default chain (single-account behavior).
+func LoadOptions(ctx context.Context, o Options) []func(*config.LoadOptions) error {
+	opts := []func(*config.LoadOptions) error{config.WithRegion(o.Region)}
+	if o.AssumeRoleARN == "" {
+		return opts
+	}
+
+	// Base config (instance role) used only to call sts:AssumeRole into the per-user role.
+	base, err := config.LoadDefaultConfig(ctx, config.WithRegion(o.Region))
+	if err != nil {
+		// Fall back to the default chain; the caller's LoadDefaultConfig will surface any error.
+		return opts
+	}
+	stsClient := sts.NewFromConfig(base)
+	sessionName := o.SessionName
+	if sessionName == "" {
+		sessionName = "ood-adapter"
+	}
+	provider := stscreds.NewAssumeRoleProvider(stsClient, o.AssumeRoleARN, func(p *stscreds.AssumeRoleOptions) {
+		p.RoleSessionName = sessionName
+		if o.ExternalID != "" {
+			p.ExternalID = aws.String(o.ExternalID)
+		}
+	})
+	return append(opts, config.WithCredentialsProvider(aws.NewCredentialsCache(provider)))
+}

--- a/internal/awscfg/awscfg_test.go
+++ b/internal/awscfg/awscfg_test.go
@@ -1,0 +1,27 @@
+package awscfg
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLoadOptions_NoAssumeRole(t *testing.T) {
+	// Empty AssumeRoleARN => exactly the region option, no credentials provider (single-account).
+	opts := LoadOptions(context.Background(), Options{Region: "us-west-2"})
+	if len(opts) != 1 {
+		t.Fatalf("expected 1 option (region only) when no role, got %d", len(opts))
+	}
+}
+
+func TestLoadOptions_WithAssumeRole(t *testing.T) {
+	// A role ARN appends a credentials-provider option on top of the region option.
+	opts := LoadOptions(context.Background(), Options{
+		Region:        "us-west-2",
+		AssumeRoleARN: "arn:aws:iam::123456789012:role/ood-user-demo",
+		ExternalID:    "ood",
+		SessionName:   "demo",
+	})
+	if len(opts) != 2 {
+		t.Fatalf("expected 2 options (region + creds provider) when role set, got %d", len(opts))
+	}
+}

--- a/internal/ec2/client.go
+++ b/internal/ec2/client.go
@@ -18,8 +18,11 @@ type Client struct {
 }
 
 // New creates an EC2 client using the default AWS credential chain.
-func New(ctx context.Context, region string) (*Client, error) {
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+func New(ctx context.Context, region string, optFns ...func(*config.LoadOptions) error) (*Client, error) {
+	if len(optFns) == 0 {
+		optFns = []func(*config.LoadOptions) error{config.WithRegion(region)}
+	}
+	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
 	if err != nil {
 		return nil, fmt.Errorf("load AWS config: %w", err)
 	}


### PR DESCRIPTION
Adds the per-user AssumeRole capability for the aws-openondemand #78 multi-account topology. **Default-off** — empty `--assume-role-arn` is byte-identical to today (instance role); when set, the adapter assumes a per-user role via STS (ExternalID + session name from the OOD username). New `internal/awscfg` helper + 3 flags, wired through the existing `config.LoadDefaultConfig(optFns...)` seam. Table-driven test. Verified: build/vet/test, goreleaser check, `--assume-role-arn` present.